### PR TITLE
Added __enter__ and __exit__ for scoped use

### DIFF
--- a/l3ns/base/network.py
+++ b/l3ns/base/network.py
@@ -154,6 +154,13 @@ class Network:
         self._available_subnets.sort(key=lambda n: 32 - n.prefixlen)
 
         return smaller_subnet
+    
+    def __enter__(self):
+        self.start()
+        return self
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.stop()
 
 
 class NetworkConcurrent(Network):


### PR DESCRIPTION
So one could write:
```
from l3ns.ldc import DockerNode
from l3ns.base.network import Network
from l3ns import defaults

defaults.network = Network('29.0.0.0/8')

n1 = DockerNode('test1',  image='alpine', command='ping 8.8.8.8', tty=True, stdin_open=True)
n2 = DockerNode('test2',  image='alpine', command='tail -f /dev/null')

n1.connect_to(n2)
n1.connect_to_internet = True
with defaults.network:
    log = n1.exec_run("ping -c 10 8.8.8.8", stderr=True,  stdout=True, stream=True)

    for line in log[1]:
        print(line)

```
instead of start\stop pair