### PR TITLE
Network namespaces runtime

### DIFF
--- a/examples/namespaces/two_nodes.py
+++ b/examples/namespaces/two_nodes.py
@@ -1,0 +1,13 @@
+from l3ns.namespaces import NamespaceNode, NamespaceSubnet
+from l3ns import defaults
+from pyroute2.ndb.main import NDB
+
+ndb = NDB()
+
+n1 = NamespaceNode('t1', ['tail', '-f', '/dev/null'], ndb=ndb)
+n2 = NamespaceNode('t2', ['tail', '-f', '/dev/null'], ndb=ndb)
+
+n1.connect_to(n2, subnet_class=NamespaceSubnet, ndb=ndb)
+
+
+defaults.network.start(interactive=True)

--- a/l3ns/base/node.py
+++ b/l3ns/base/node.py
@@ -84,6 +84,10 @@ class BaseNode:
 
         return ret
 
+    def stop(self, *args, **kwargs):
+        """Stop function to be implemented in resource-specific classed, like DockerNode"""
+        raise NotImplementedError()
+
     def _connect_subnets(self):
         for ip, network in self._interfaces.items():
             self._connect_subnet(network, ip)

--- a/l3ns/base/subnet.py
+++ b/l3ns/base/subnet.py
@@ -85,7 +85,7 @@ class BaseSubnet:
 
         If this subnet resides in a local network and has LAN gateway
         (i.e. Node that belongs both to local and wide area networks and
-        has NAT protocol configured), than lan gateway will be used
+        has NAT protocol configured), lan gateway will be used
         as default gateway.
         If there is no LAN gateway in the subnet, random router
         will be used as default gateway.

--- a/l3ns/cluster/node.py
+++ b/l3ns/cluster/node.py
@@ -1,5 +1,4 @@
 import os
-import hashids
 
 from .. import ldc
 from .utils import my_hash, generate_wg_keys, ClusterHost, vpn_server_address

--- a/l3ns/ldc/utils.py
+++ b/l3ns/ldc/utils.py
@@ -1,4 +1,4 @@
 import docker
 
-docker_client = docker.from_env()
+docker_client = None # docker.from_env()
 

--- a/l3ns/namespaces/__init__.py
+++ b/l3ns/namespaces/__init__.py
@@ -1,0 +1,2 @@
+from .node import NamespaceNode
+from .subnet import NamespaceSubnet

--- a/l3ns/namespaces/node.py
+++ b/l3ns/namespaces/node.py
@@ -70,9 +70,11 @@ class NamespaceNode(base.BaseNode):
 
     def _deploy_routes(self):
         for ip_range, gateway in self._routes.items():
-            status_code, output = self.container.exec_run('ip route add {} via '.format(ip_range) + gateway)
-            if status_code:
-                print('Error({2}) while setting routes for {0}:\n{1}'.format(self.name, output.decode(), status_code))
+            self._ndb.route.create(
+                dst=ip_range,
+                gateway=gateway,
+                target=self._ns_name
+            ).commit()
 
     @classmethod
     def make_router(cls, *args, **kwargs):

--- a/l3ns/namespaces/node.py
+++ b/l3ns/namespaces/node.py
@@ -1,0 +1,97 @@
+import docker
+import tarfile
+import io
+import os
+import time
+
+from pyroute2.nslink.nspopen import NSPopen
+
+from .. import base
+from ..cluster.utils import my_hash
+
+
+class NamespaceNode(base.BaseNode):
+
+    def __init__(self, name, args, *, ndb, **popen_kwargs):
+        self._args = args
+        self._ndb = ndb
+        self._ns_name = name
+        self._veths = {}
+        self._popen = None
+        self._popen_kwargs = popen_kwargs
+        super().__init__(name=name)
+
+    def _connect_subnet(self, subnet, ip):
+        ifc_hash = my_hash(subnet.name, self.name)
+        ifc = self._ndb.interfaces.create(
+            ifname=f'l3eth_{ifc_hash}',
+            kind='veth',
+            peer=f'l3br_{ifc_hash}',
+        ).commit()
+
+        self._ndb.interfaces[ifc['ifname']].set(
+            'target', self._ns_name
+        ).commit()
+
+        veth_ns = self._ndb.interfaces[{
+            'target': self._ns_name,
+            'ifname': ifc['ifname']
+        }].add_ip(
+            f'{ip}/{subnet._ip_range.prefixlen}'
+        ).set('state', 'up').commit()
+
+        veth_br = self._ndb.interfaces[ifc['peer']].set(
+            'master', subnet.bridge['index']
+        ).set('state', 'up').commit()
+
+        self._veths[subnet] = (veth_br, veth_ns)
+
+    def _start(self):
+        self._ns = self._ndb.netns.create(self._ns_name).commit()
+        self._ndb.sources.add(netns=self._ns_name)
+
+        self._popen = NSPopen(self._ns_name, self._args, **self._popen_kwargs)
+
+    def load(self):
+        pass
+
+    def stop(self):
+        # TODO: not sure if both are necessary
+        self._popen.terminate()
+        self._popen.release()
+
+        for veth_br, veth_ns in self._veths.values():
+            veth_br.remove().commit()
+
+        self._ns.remove().commit()
+
+    def put_string(self, path, string):
+        raise NotImplementedError('Network namespace has access to the local filesystem!')
+
+    def _deploy_routes(self):
+        for ip_range, gateway in self._routes.items():
+            status_code, output = self.container.exec_run('ip route add {} via '.format(ip_range) + gateway)
+            if status_code:
+                print('Error({2}) while setting routes for {0}:\n{1}'.format(self.name, output.decode(), status_code))
+
+    @classmethod
+    def make_router(cls, *args, **kwargs):
+
+        kwargs = kwargs.copy()
+
+        # TODO: frr should be accessible in the system
+        kwargs['image'] = 'frrouting/frr'
+
+        router = cls(*args, **kwargs)
+
+        router.is_router = True
+
+        return router
+
+    def activate_protocol(self, protocol: str, config: str):
+        # TODO: how to run multiple FRR in the same system?
+        daemon_name = protocol.lower() + 'd'
+        cmd = "sed -i 's/{daemon}=no/{daemon}=yes/' /etc/frr/daemons &&".format(daemon=daemon_name)
+        self._docker_kwargs['entrypoint'] = cmd + self._docker_kwargs['entrypoint']
+
+        self.put_string('/etc/frr/{}.conf'.format(daemon_name), config)

--- a/l3ns/namespaces/subnet.py
+++ b/l3ns/namespaces/subnet.py
@@ -1,0 +1,25 @@
+from pyroute2.ndb.main import NDB
+
+from .. import base
+
+
+class NamespaceSubnet(base.BaseSubnet):
+    def __init__(self, *args, ndb, size=1023, **kwargs,):
+        self._ndb = ndb
+
+        self.bridge = None
+        super().__init__(*args, size=size + 1, **kwargs)
+        # minus one address for docker gateway
+        self._docker_gateway = self._get_host_ip()
+
+    def start(self):
+        self.bridge = self._ndb.interfaces.create(
+            ifname=f'l3br_{self.name}',
+            kind='bridge'
+        ).set('state', 'up').commit()
+
+    def load(self):
+        pass
+
+    def stop(self):
+        self.bridge.remove().commit()

--- a/l3ns/namespaces/subnet.py
+++ b/l3ns/namespaces/subnet.py
@@ -9,8 +9,6 @@ class NamespaceSubnet(base.BaseSubnet):
 
         self.bridge = None
         super().__init__(*args, size=size + 1, **kwargs)
-        # minus one address for docker gateway
-        self._docker_gateway = self._get_host_ip()
 
     def start(self):
         self.bridge = self._ndb.interfaces.create(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 paramiko
 docker
-hashids
+pyroute2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
           'docker',
-          'hashids',
       ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
To do list:
- [x] initial setup for a virtual networking via virtual bridges for a simple network topology with no routers
- [ ] figure out how to run multiple FRRouting instances on the same machine
- [ ] examples and testing for complex topos, with LAN and routers
- [ ] optimize pyroute2 transaction management
- [ ] properly dispose of NDB instance 
- [ ] proper context management (NDB instance/docker client)

Caveats: 
* Docker breaks native bridge interfaces, so namespaces runtime can really run with docker running at the same time [3] 
* `Popen` processes are not too straightforward to open nor close

References:
1. [pyroute2 docs](https://docs.pyroute2.org)
2. [pyroute2 issues](https://github.com/svinota/pyroute2/issues)
3. [Docker breaks iproutes tables for bridge interfaces on startup](https://unix.stackexchange.com/questions/671644/cant-establish-communication-between-two-network-namespaces-using-bridge-network)
4. [FRRouting documentation on network namespaces](https://docs.frrouting.org/en/latest/setup.html#network-namespaces)